### PR TITLE
feat: add Settings menu item to macOS app menu

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,6 +1,6 @@
 import { execFileSync } from "node:child_process";
 import path from "node:path";
-import { app, BrowserWindow } from "electron";
+import { app, BrowserWindow, Menu } from "electron";
 import { createDatabase } from "./db/connection.js";
 import { resetStaleSessions } from "./db/sessions.js";
 import { applyDockIcon } from "./dock.js";
@@ -81,6 +81,59 @@ app.whenReady().then(() => {
   applyDockIcon(settings.appIcon);
 
   createWindow();
+
+  const menu = Menu.buildFromTemplate([
+    {
+      label: app.name,
+      submenu: [
+        { role: "about" },
+        { type: "separator" },
+        {
+          label: "Settings...",
+          accelerator: "Cmd+,",
+          click: () => mainWindow?.webContents.send("menu:settings"),
+        },
+        { type: "separator" },
+        { role: "hide" },
+        { role: "hideOthers" },
+        { role: "unhide" },
+        { type: "separator" },
+        { role: "quit" },
+      ],
+    },
+    {
+      label: "Edit",
+      submenu: [
+        { role: "undo" },
+        { role: "redo" },
+        { type: "separator" },
+        { role: "cut" },
+        { role: "copy" },
+        { role: "paste" },
+        { role: "selectAll" },
+      ],
+    },
+    {
+      label: "View",
+      submenu: [
+        { role: "reload" },
+        { role: "forceReload" },
+        { role: "toggleDevTools" },
+        { type: "separator" },
+        { role: "resetZoom" },
+        { role: "zoomIn" },
+        { role: "zoomOut" },
+        { type: "separator" },
+        { role: "togglefullscreen" },
+      ],
+    },
+    {
+      label: "Window",
+      submenu: [{ role: "minimize" }, { role: "zoom" }, { role: "close" }],
+    },
+  ]);
+  Menu.setApplicationMenu(menu);
+
   setupUpdater();
 
   app.on("activate", () => {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -47,6 +47,7 @@ const CH = {
   EVENT_UPDATE_DOWNLOADED: "updater:update-downloaded",
   EVENT_UPDATE_PROGRESS: "updater:progress",
   EVENT_UPDATE_ERROR: "updater:error",
+  EVENT_MENU_SETTINGS: "menu:settings",
 } as const;
 
 const api = {
@@ -154,6 +155,11 @@ const api = {
     const handler = (_event: unknown, info: { error: string }) => callback(info);
     ipcRenderer.on(CH.EVENT_UPDATE_ERROR, handler);
     return () => ipcRenderer.removeListener(CH.EVENT_UPDATE_ERROR, handler);
+  },
+  onMenuSettings: (callback: () => void) => {
+    const handler = () => callback();
+    ipcRenderer.on(CH.EVENT_MENU_SETTINGS, handler);
+    return () => ipcRenderer.removeListener(CH.EVENT_MENU_SETTINGS, handler);
   },
 };
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -9,6 +9,7 @@ import { useThemeStore } from "./stores/themeStore";
 export function App() {
   const handleStatusChange = useSessionStore((state) => state.handleStatusChange);
   const loadTheme = useThemeStore((state) => state.loadTheme);
+  const toggleSettings = useThemeStore((state) => state.toggleSettings);
 
   useGlobalShortcuts();
 
@@ -24,6 +25,12 @@ export function App() {
       unsubStatus();
     };
   }, [handleStatusChange]);
+
+  // Subscribe to menu → Settings
+  useEffect(() => {
+    if (!window.electronAPI) return;
+    return window.electronAPI.onMenuSettings(toggleSettings);
+  }, [toggleSettings]);
 
   return (
     <div className="flex h-screen select-none bg-base">

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -62,4 +62,5 @@ export const IPC = {
   EVENT_UPDATE_DOWNLOADED: "updater:update-downloaded",
   EVENT_UPDATE_PROGRESS: "updater:progress",
   EVENT_UPDATE_ERROR: "updater:error",
+  EVENT_MENU_SETTINGS: "menu:settings",
 } as const;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -93,6 +93,7 @@ export interface ElectronAPI {
     callback: (progress: { percent: number; bytesPerSecond: number; transferred: number; total: number }) => void,
   ) => () => void;
   onUpdateError: (callback: (info: { error: string }) => void) => () => void;
+  onMenuSettings: (callback: () => void) => () => void;
 }
 
 declare global {


### PR DESCRIPTION
## Summary
- Adds a proper Electron `Menu` with **Settings...** (Cmd+,) under the app submenu
- Includes standard Edit, View, and Window menus (undo/redo, copy/paste, zoom, devtools, etc.)
- Menu item sends IPC event to renderer to toggle the existing settings panel

## Test plan
- [ ] Cmd+, opens settings from both keyboard shortcut and menu item
- [ ] Standard Edit menu items work (copy, paste, undo, redo, select all)
- [ ] View menu devtools/reload works
- [ ] Unit tests pass
- [ ] E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)