### PR TITLE
fix: auto-focus terminal on new session creation

### DIFF
--- a/src/renderer/components/SessionView/TerminalView.tsx
+++ b/src/renderer/components/SessionView/TerminalView.tsx
@@ -178,6 +178,12 @@ export function TerminalView({ sessionId, agentType, worktreePath, isActive }: T
         });
       });
       resizeObserver.observe(container);
+
+      // Focus the terminal if this session is already active (e.g. just created).
+      // The isActive effect won't fire because isActive was true from the start.
+      if (isActiveRef.current) {
+        terminal.focus();
+      }
     });
 
     return () => {


### PR DESCRIPTION
## Summary

Auto-focus the terminal when a new session is created and becomes the active session. This ensures keyboard input works immediately without requiring a manual click on the terminal area.

## Problem

When a new session is created as the active session:
1. The session state is set to active immediately
2. TerminalView initializes the xterm instance in a `requestAnimationFrame`
3. The focus effect fires on mount when `isActive` is already `true`, but `terminalRef.current` is still `null`
4. The focus effect never re-fires because `isActive` never *changes* after mount

This caused users to need to click the terminal before they could input anything, including responding to Claude's folder trust prompts.

## Solution

Add an explicit `terminal.focus()` call at the end of the initialization RAF when the session is already active. This handles the case where a terminal is created for an already-active session.

## Testing

- All existing tests pass (217/217)
- Manual test: Create new session → terminal auto-focuses, keyboard input works immediately
- Tested with Claude's folder trust prompt → no click needed to press Enter

## What Changed

- `src/renderer/components/SessionView/TerminalView.tsx`: Added focus call after terminal initialization when session is already active