### PR TITLE
fix: force layout recalculation on window visibility change

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -29,6 +29,20 @@ export function App() {
     };
   }, [handleStatusChange]);
 
+  // Force layout recalculation when app becomes visible again.
+  // macOS can report stale viewport dimensions when restoring a window
+  // (e.g. switching spaces, waking from sleep), which leaves the bottom
+  // half of the app blank.
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (!document.hidden) {
+        window.dispatchEvent(new Event("resize"));
+      }
+    };
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () => document.removeEventListener("visibilitychange", handleVisibilityChange);
+  }, []);
+
   // Subscribe to menu → Settings
   useEffect(() => {
     if (!window.electronAPI) return;


### PR DESCRIPTION
## Summary
- Adds a `visibilitychange` event listener that dispatches a synthetic `resize` event when the document becomes visible
- Fixes an intermittent bug where the bottom half of the app renders blank after returning from another app/space/sleep

## Context
macOS can report stale viewport dimensions when restoring a window (e.g. switching spaces, waking from sleep), causing `100vh` to resolve incorrectly. The `ResizeObserver` on terminal containers doesn't fire because the window size hasn't changed — only the viewport calculation is stale. Dispatching a synthetic resize forces a full layout recalculation.

## Test plan
- [x] 217/217 unit tests pass
- [x] 6/7 E2E tests pass (1 pre-existing flaky timeout)
- [x] Manual verification in dev mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)