### PR TITLE
feat: add notifications and unread state for sessions

### DIFF
--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -1,7 +1,7 @@
 import { execFileSync, spawn } from "node:child_process";
 import fs from "node:fs";
 import type Database from "better-sqlite3";
-import { app, type BrowserWindow, dialog, ipcMain } from "electron";
+import { app, type BrowserWindow, dialog, ipcMain, Notification } from "electron";
 import { getFonts2 } from "font-list";
 import * as pty from "node-pty";
 import type { AgentType } from "../shared/agent-types.js";
@@ -84,6 +84,27 @@ export function registerIpcHandlers(options: RegisterHandlersOptions): void {
     const window = getMainWindow();
     if (window) {
       window.webContents.send(IPC.EVENT_SESSION_STATUS, sessionId, status);
+    }
+
+    if (status === "waiting_for_input") {
+      const settings = readSettings(settingsPath);
+      if (settings.notificationsEnabled !== false && !window?.isFocused()) {
+        const session = getSession(db, sessionId);
+        const sessionName = session?.name || "Session";
+        const notification = new Notification({
+          title: sessionName,
+          body: "Waiting for your input",
+        });
+        notification.on("click", () => {
+          const win = getMainWindow();
+          if (win) {
+            win.show();
+            win.focus();
+            win.webContents.send(IPC.EVENT_NAVIGATE_TO_SESSION, sessionId);
+          }
+        });
+        notification.show();
+      }
     }
   });
 

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -50,6 +50,7 @@ const CH = {
   EVENT_UPDATE_PROGRESS: "updater:progress",
   EVENT_UPDATE_ERROR: "updater:error",
   EVENT_MENU_SETTINGS: "menu:settings",
+  EVENT_NAVIGATE_TO_SESSION: "event:navigateToSession",
 } as const;
 
 const api = {
@@ -166,6 +167,11 @@ const api = {
     const handler = () => callback();
     ipcRenderer.on(CH.EVENT_MENU_SETTINGS, handler);
     return () => ipcRenderer.removeListener(CH.EVENT_MENU_SETTINGS, handler);
+  },
+  onNavigateToSession: (callback: (sessionId: string) => void) => {
+    const handler = (_event: unknown, sessionId: string) => callback(sessionId);
+    ipcRenderer.on(CH.EVENT_NAVIGATE_TO_SESSION, handler);
+    return () => ipcRenderer.removeListener(CH.EVENT_NAVIGATE_TO_SESSION, handler);
   },
 };
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -9,6 +9,7 @@ import { useThemeStore } from "./stores/themeStore";
 
 export function App() {
   const handleStatusChange = useSessionStore((state) => state.handleStatusChange);
+  const setActiveSession = useSessionStore((state) => state.setActiveSession);
   const loadTheme = useThemeStore((state) => state.loadTheme);
   const loadFonts = useFontStore((state) => state.loadFonts);
   const toggleSettings = useThemeStore((state) => state.toggleSettings);
@@ -42,6 +43,12 @@ export function App() {
     document.addEventListener("visibilitychange", handleVisibilityChange);
     return () => document.removeEventListener("visibilitychange", handleVisibilityChange);
   }, []);
+
+  // Navigate to session when notification is clicked
+  useEffect(() => {
+    if (!window.electronAPI) return;
+    return window.electronAPI.onNavigateToSession(setActiveSession);
+  }, [setActiveSession]);
 
   // Subscribe to menu → Settings
   useEffect(() => {

--- a/src/renderer/components/SettingsPanel/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel/SettingsPanel.tsx
@@ -38,6 +38,7 @@ export function SettingsPanel() {
   const [iconDataUrls, setIconDataUrls] = useState<Record<string, string>>({});
   const [appVersion, setAppVersion] = useState("");
   const [worktreeBaseDir, setWorktreeBaseDir] = useState<string | undefined>();
+  const [notificationsEnabled, setNotificationsEnabled] = useState(true);
 
   const [updateState, setUpdateState] = useState<UpdateState>("idle");
   const [updateInfo, setUpdateInfo] = useState<UpdateInfo>({});
@@ -48,6 +49,7 @@ export function SettingsPanel() {
     window.electronAPI.getSettings().then((settings) => {
       setActiveIcon(settings.appIcon ?? "icon-01");
       setWorktreeBaseDir(settings.worktreeBaseDir);
+      setNotificationsEnabled(settings.notificationsEnabled !== false);
     });
     window.electronAPI.getIconDataUrls().then(setIconDataUrls);
     window.electronAPI.listFonts().then(setFonts);
@@ -129,6 +131,13 @@ export function SettingsPanel() {
     }
   }, []);
 
+  const handleToggleNotifications = useCallback(async () => {
+    if (!window.electronAPI) return;
+    const next = !notificationsEnabled;
+    setNotificationsEnabled(next);
+    await window.electronAPI.saveSettings({ notificationsEnabled: next });
+  }, [notificationsEnabled]);
+
   const handleClearWorktreeDir = useCallback(async () => {
     if (!window.electronAPI) return;
     setWorktreeBaseDir(undefined);
@@ -204,6 +213,29 @@ export function SettingsPanel() {
             >
               {worktreeBaseDir ? "Change Folder..." : "Choose Folder..."}
             </button>
+          </div>
+        </div>
+
+        {/* Notifications section */}
+        <div className="mb-6">
+          <h3 className="text-sm font-medium text-text-secondary mb-3">Notifications</h3>
+          <div className="rounded-lg bg-surface border border-border-subtle p-4">
+            <div className="flex items-center justify-between">
+              <span className="text-xs text-text-secondary">
+                Show macOS notifications when a session is waiting for input
+              </span>
+              <button
+                type="button"
+                onClick={handleToggleNotifications}
+                className={`text-xs font-medium px-3 py-1.5 rounded-md transition-colors cursor-pointer ${
+                  notificationsEnabled
+                    ? "bg-accent/15 text-accent hover:bg-accent/25"
+                    : "bg-white/5 text-text-muted hover:bg-white/10"
+                }`}
+              >
+                {notificationsEnabled ? "Enabled" : "Disabled"}
+              </button>
+            </div>
           </div>
         </div>
 

--- a/src/renderer/components/Sidebar/SessionListItem.tsx
+++ b/src/renderer/components/Sidebar/SessionListItem.tsx
@@ -4,6 +4,8 @@ import type { SessionInfo } from "@shared/agent-types";
 export interface SessionListItemProps {
   session: SessionInfo;
   isActive: boolean;
+  isUnread?: boolean;
+  isMarkUnreadTarget?: boolean;
   onClick: () => void;
   onArchive?: () => void;
   onRestore?: () => void;
@@ -30,6 +32,8 @@ function folderName(repoPath: string): string {
 export function SessionListItem({
   session,
   isActive,
+  isUnread,
+  isMarkUnreadTarget,
   onClick,
   onArchive,
   onRestore,
@@ -98,11 +102,18 @@ export function SessionListItem({
         </div>
       )}
 
-      {/* Chat bubble for waiting sessions — hidden when active or on hover */}
-      {session.status === "waiting_for_input" && !isActive && (
+      {/* Chat bubble for unread sessions — hidden when active or on hover */}
+      {isUnread && !isActive && (
         <div className="shrink-0 text-warning group-hover:hidden">
           <ChatBubbleIcon />
         </div>
+      )}
+
+      {/* "U" badge — shown on active session when Cmd is held (mark-unread hint) */}
+      {isMarkUnreadTarget && (
+        <span className="absolute right-1 top-1/2 -translate-y-1/2 w-5 h-5 flex items-center justify-center rounded bg-warning/80 text-[10px] font-semibold text-white shadow-sm">
+          U
+        </span>
       )}
 
       {/* Hover actions */}

--- a/src/renderer/components/Sidebar/Sidebar.tsx
+++ b/src/renderer/components/Sidebar/Sidebar.tsx
@@ -32,6 +32,7 @@ export function Sidebar() {
   const loadRepos = useRepoStore((state) => state.loadRepos);
   const addRepoViaDialog = useRepoStore((state) => state.addRepoViaDialog);
 
+  const unreadSessionIds = useSessionStore((state) => state.unreadSessionIds);
   const reorderSessions = useSessionStore((state) => state.reorderSessions);
 
   const [archiveOpen, setArchiveOpen] = useState(false);
@@ -201,6 +202,8 @@ export function Sidebar() {
                   key={session.id}
                   session={session}
                   isActive={session.id === activeSessionId}
+                  isUnread={unreadSessionIds.has(session.id)}
+                  isMarkUnreadTarget={metaHeld && session.id === activeSessionId}
                   onClick={() => setActiveSession(session.id)}
                   onArchive={() => handleArchiveSession(session)}
                   branchName={session.branchName ?? branches.get(session.repoPath)}

--- a/src/renderer/hooks/useGlobalShortcuts.test.ts
+++ b/src/renderer/hooks/useGlobalShortcuts.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isNewSessionShortcut, isSettingsShortcut } from "./useGlobalShortcuts";
+import { isMarkUnreadShortcut, isNewSessionShortcut, isSettingsShortcut } from "./useGlobalShortcuts";
 
 describe("isSettingsShortcut", () => {
   it("returns true for Cmd+,", () => {
@@ -42,5 +42,27 @@ describe("isNewSessionShortcut", () => {
   it("returns false for Cmd+Shift+N", () => {
     const event = { key: "n", metaKey: true, ctrlKey: false, shiftKey: true, altKey: false };
     expect(isNewSessionShortcut(event as KeyboardEvent)).toBe(false);
+  });
+});
+
+describe("isMarkUnreadShortcut", () => {
+  it("returns true for Cmd+U", () => {
+    const event = { key: "u", metaKey: true, ctrlKey: false, shiftKey: false, altKey: false };
+    expect(isMarkUnreadShortcut(event as KeyboardEvent)).toBe(true);
+  });
+
+  it("returns false without meta", () => {
+    const event = { key: "u", metaKey: false, ctrlKey: false, shiftKey: false, altKey: false };
+    expect(isMarkUnreadShortcut(event as KeyboardEvent)).toBe(false);
+  });
+
+  it("returns false for Cmd+Shift+U", () => {
+    const event = { key: "u", metaKey: true, ctrlKey: false, shiftKey: true, altKey: false };
+    expect(isMarkUnreadShortcut(event as KeyboardEvent)).toBe(false);
+  });
+
+  it("returns false for Cmd+Alt+U", () => {
+    const event = { key: "u", metaKey: true, ctrlKey: false, shiftKey: false, altKey: true };
+    expect(isMarkUnreadShortcut(event as KeyboardEvent)).toBe(false);
   });
 });

--- a/src/renderer/hooks/useGlobalShortcuts.ts
+++ b/src/renderer/hooks/useGlobalShortcuts.ts
@@ -11,9 +11,14 @@ export function isNewSessionShortcut(event: KeyboardEvent): boolean {
   return event.key === "n" && event.metaKey && !event.shiftKey && !event.altKey && !event.ctrlKey;
 }
 
+export function isMarkUnreadShortcut(event: KeyboardEvent): boolean {
+  return event.key === "u" && event.metaKey && !event.shiftKey && !event.altKey && !event.ctrlKey;
+}
+
 export function useGlobalShortcuts(): void {
   const toggleSettings = useThemeStore((state) => state.toggleSettings);
   const setPendingNewSessionRepo = useSessionStore((state) => state.setPendingNewSessionRepo);
+  const markUnread = useSessionStore((state) => state.markUnread);
   const addRepoViaDialog = useRepoStore((state) => state.addRepoViaDialog);
 
   useEffect(() => {
@@ -30,9 +35,17 @@ export function useGlobalShortcuts(): void {
           setPendingNewSessionRepo(repo);
         }
       }
+
+      if (isMarkUnreadShortcut(event)) {
+        event.preventDefault();
+        const activeSessionId = useSessionStore.getState().activeSessionId;
+        if (activeSessionId) {
+          markUnread(activeSessionId);
+        }
+      }
     }
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [toggleSettings, setPendingNewSessionRepo, addRepoViaDialog]);
+  }, [toggleSettings, setPendingNewSessionRepo, markUnread, addRepoViaDialog]);
 }

--- a/src/renderer/stores/sessionStore.test.ts
+++ b/src/renderer/stores/sessionStore.test.ts
@@ -1,7 +1,137 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useSessionStore } from "./sessionStore";
 
-describe("sessionStore", () => {
-  it("placeholder — store tests use Zustand internals and need jsdom", () => {
-    expect(true).toBe(true);
+// Minimal mock for window.electronAPI — only methods called by the store
+const mockElectronAPI = {
+  ptyKill: vi.fn().mockResolvedValue(undefined),
+  deleteSession: vi.fn().mockResolvedValue(undefined),
+  archiveSession: vi.fn().mockResolvedValue(undefined),
+  listSessions: vi.fn().mockResolvedValue([]),
+  listArchivedSessions: vi.fn().mockResolvedValue([]),
+};
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  (globalThis as unknown as { window: { electronAPI: typeof mockElectronAPI } }).window = {
+    electronAPI: mockElectronAPI,
+  };
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  useSessionStore.setState({
+    sessions: [],
+    archivedSessions: [],
+    activeSessionId: null,
+    unreadSessionIds: new Set(),
+  });
+});
+
+function seedSessions() {
+  useSessionStore.setState({
+    sessions: [
+      {
+        id: "s1",
+        repoPath: "/repo",
+        worktreePath: "/repo",
+        agentType: "claude",
+        status: "running",
+        name: "S1",
+        branchName: null,
+        agentSessionId: null,
+        createdAt: "",
+        sortOrder: 0,
+      },
+      {
+        id: "s2",
+        repoPath: "/repo",
+        worktreePath: "/repo",
+        agentType: "claude",
+        status: "running",
+        name: "S2",
+        branchName: null,
+        agentSessionId: null,
+        createdAt: "",
+        sortOrder: 1,
+      },
+    ],
+    activeSessionId: "s1",
+  });
+}
+
+describe("unread state", () => {
+  it("marks non-active session unread on waiting_for_input", () => {
+    seedSessions();
+    useSessionStore.getState().handleStatusChange("s2", "waiting_for_input");
+    expect(useSessionStore.getState().unreadSessionIds.has("s2")).toBe(true);
+  });
+
+  it("does NOT mark the active session unread", () => {
+    seedSessions();
+    useSessionStore.getState().handleStatusChange("s1", "waiting_for_input");
+    expect(useSessionStore.getState().unreadSessionIds.has("s1")).toBe(false);
+  });
+
+  it("clears unread when status changes to running", () => {
+    seedSessions();
+    useSessionStore.setState({ unreadSessionIds: new Set(["s2"]) });
+    useSessionStore.getState().handleStatusChange("s2", "running");
+    expect(useSessionStore.getState().unreadSessionIds.has("s2")).toBe(false);
+  });
+
+  it("clears unread when status changes to archived", () => {
+    seedSessions();
+    useSessionStore.setState({ unreadSessionIds: new Set(["s2"]) });
+    useSessionStore.getState().handleStatusChange("s2", "archived");
+    expect(useSessionStore.getState().unreadSessionIds.has("s2")).toBe(false);
+  });
+
+  it("markUnread adds to the set", () => {
+    seedSessions();
+    useSessionStore.getState().markUnread("s1");
+    expect(useSessionStore.getState().unreadSessionIds.has("s1")).toBe(true);
+  });
+
+  it("markRead removes from the set", () => {
+    seedSessions();
+    useSessionStore.setState({ unreadSessionIds: new Set(["s1"]) });
+    useSessionStore.getState().markRead("s1");
+    expect(useSessionStore.getState().unreadSessionIds.has("s1")).toBe(false);
+  });
+
+  it("setActiveSession clears unread after 1500ms", () => {
+    seedSessions();
+    useSessionStore.setState({ unreadSessionIds: new Set(["s2"]) });
+    useSessionStore.getState().setActiveSession("s2");
+    // Not cleared immediately
+    expect(useSessionStore.getState().unreadSessionIds.has("s2")).toBe(true);
+    vi.advanceTimersByTime(1500);
+    expect(useSessionStore.getState().unreadSessionIds.has("s2")).toBe(false);
+  });
+
+  it("setActiveSession cancels timer if session changes before 1500ms", () => {
+    seedSessions();
+    useSessionStore.setState({ unreadSessionIds: new Set(["s2"]) });
+    useSessionStore.getState().setActiveSession("s2");
+    // Switch away before timer fires
+    vi.advanceTimersByTime(500);
+    useSessionStore.getState().setActiveSession("s1");
+    vi.advanceTimersByTime(1500);
+    // s2 should still be unread — timer was cancelled
+    expect(useSessionStore.getState().unreadSessionIds.has("s2")).toBe(true);
+  });
+
+  it("deleteSession removes from unread set", async () => {
+    seedSessions();
+    useSessionStore.setState({ unreadSessionIds: new Set(["s2"]) });
+    await useSessionStore.getState().deleteSession("s2");
+    expect(useSessionStore.getState().unreadSessionIds.has("s2")).toBe(false);
+  });
+
+  it("archiveSession removes from unread set", async () => {
+    seedSessions();
+    useSessionStore.setState({ unreadSessionIds: new Set(["s2"]) });
+    await useSessionStore.getState().archiveSession("s2");
+    expect(useSessionStore.getState().unreadSessionIds.has("s2")).toBe(false);
   });
 });

--- a/src/renderer/stores/sessionStore.ts
+++ b/src/renderer/stores/sessionStore.ts
@@ -4,10 +4,13 @@ import { create } from "zustand";
 
 type WorktreeDialogContext = "archive" | "delete";
 
+let readTimerId: ReturnType<typeof setTimeout> | null = null;
+
 interface SessionState {
   sessions: SessionInfo[];
   archivedSessions: SessionInfo[];
   activeSessionId: string | null;
+  unreadSessionIds: Set<string>;
   pendingNewSessionRepo: RepoInfo | null;
   pendingWorktreeSession: SessionInfo | null;
   pendingWorktreeContext: WorktreeDialogContext | null;
@@ -17,6 +20,8 @@ interface SessionState {
   loadArchivedSessions: () => Promise<void>;
   createSession: (repoPath: string, agentType: "claude" | "gemini", branchName?: string) => Promise<SessionInfo>;
   setActiveSession: (sessionId: string | null) => void;
+  markUnread: (sessionId: string) => void;
+  markRead: (sessionId: string) => void;
   deleteSession: (sessionId: string) => Promise<void>;
   archiveSession: (sessionId: string) => Promise<void>;
   archiveSessionWithWorktreeCleanup: (sessionId: string, deleteBranch: boolean) => Promise<void>;
@@ -29,10 +34,11 @@ interface SessionState {
   dismissWorktreeDialog: () => void;
 }
 
-export const useSessionStore = create<SessionState>((set) => ({
+export const useSessionStore = create<SessionState>((set, get) => ({
   sessions: [],
   archivedSessions: [],
   activeSessionId: null,
+  unreadSessionIds: new Set<string>(),
   pendingNewSessionRepo: null,
   pendingWorktreeSession: null,
   pendingWorktreeContext: null,
@@ -54,17 +60,53 @@ export const useSessionStore = create<SessionState>((set) => ({
   },
 
   setActiveSession: (sessionId) => {
+    if (readTimerId !== null) {
+      clearTimeout(readTimerId);
+      readTimerId = null;
+    }
     set({ activeSessionId: sessionId });
+    if (sessionId && get().unreadSessionIds.has(sessionId)) {
+      readTimerId = setTimeout(() => {
+        readTimerId = null;
+        const state = get();
+        if (state.activeSessionId === sessionId) {
+          const next = new Set(state.unreadSessionIds);
+          next.delete(sessionId);
+          set({ unreadSessionIds: next });
+        }
+      }, 1500);
+    }
+  },
+
+  markUnread: (sessionId) => {
+    set((state) => {
+      const next = new Set(state.unreadSessionIds);
+      next.add(sessionId);
+      return { unreadSessionIds: next };
+    });
+  },
+
+  markRead: (sessionId) => {
+    set((state) => {
+      const next = new Set(state.unreadSessionIds);
+      next.delete(sessionId);
+      return { unreadSessionIds: next };
+    });
   },
 
   deleteSession: async (sessionId) => {
     await window.electronAPI.ptyKill(sessionId).catch(() => {});
     await window.electronAPI.deleteSession(sessionId);
-    set((state) => ({
-      sessions: state.sessions.filter((s) => s.id !== sessionId),
-      archivedSessions: state.archivedSessions.filter((s) => s.id !== sessionId),
-      activeSessionId: state.activeSessionId === sessionId ? null : state.activeSessionId,
-    }));
+    set((state) => {
+      const next = new Set(state.unreadSessionIds);
+      next.delete(sessionId);
+      return {
+        sessions: state.sessions.filter((s) => s.id !== sessionId),
+        archivedSessions: state.archivedSessions.filter((s) => s.id !== sessionId),
+        activeSessionId: state.activeSessionId === sessionId ? null : state.activeSessionId,
+        unreadSessionIds: next,
+      };
+    });
   },
 
   archiveSession: async (sessionId) => {
@@ -73,10 +115,13 @@ export const useSessionStore = create<SessionState>((set) => ({
     set((state) => {
       const session = state.sessions.find((s) => s.id === sessionId);
       const archived = session ? { ...session, status: "archived" as const } : null;
+      const nextUnread = new Set(state.unreadSessionIds);
+      nextUnread.delete(sessionId);
       return {
         sessions: state.sessions.filter((s) => s.id !== sessionId),
         archivedSessions: archived ? [archived, ...state.archivedSessions] : state.archivedSessions,
         activeSessionId: state.activeSessionId === sessionId ? null : state.activeSessionId,
+        unreadSessionIds: nextUnread,
       };
     });
   },
@@ -149,23 +194,33 @@ export const useSessionStore = create<SessionState>((set) => ({
       set((state) => {
         const session = state.sessions.find((s) => s.id === sessionId);
         const archived = session ? { ...session, status: "archived" as const } : null;
-
-        // If session had a worktree, show cleanup dialog
         const showDialog = session?.branchName != null;
+        const nextUnread = new Set(state.unreadSessionIds);
+        nextUnread.delete(sessionId);
 
         return {
           sessions: state.sessions.filter((s) => s.id !== sessionId),
           archivedSessions: archived ? [archived, ...state.archivedSessions] : state.archivedSessions,
           activeSessionId: state.activeSessionId === sessionId ? null : state.activeSessionId,
+          unreadSessionIds: nextUnread,
           ...(showDialog && archived
             ? { pendingWorktreeSession: archived, pendingWorktreeContext: "archive" as const }
             : {}),
         };
       });
     } else {
-      set((state) => ({
-        sessions: state.sessions.map((s) => (s.id === sessionId ? { ...s, status } : s)),
-      }));
+      set((state) => {
+        const nextUnread = new Set(state.unreadSessionIds);
+        if (status === "waiting_for_input" && sessionId !== state.activeSessionId) {
+          nextUnread.add(sessionId);
+        } else if (status === "running") {
+          nextUnread.delete(sessionId);
+        }
+        return {
+          sessions: state.sessions.map((s) => (s.id === sessionId ? { ...s, status } : s)),
+          unreadSessionIds: nextUnread,
+        };
+      });
     }
   },
 

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -66,4 +66,5 @@ export const IPC = {
   EVENT_UPDATE_PROGRESS: "updater:progress",
   EVENT_UPDATE_ERROR: "updater:error",
   EVENT_MENU_SETTINGS: "menu:settings",
+  EVENT_NAVIGATE_TO_SESSION: "event:navigateToSession",
 } as const;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -30,6 +30,7 @@ export interface AppSettings {
   appIcon?: string;
   /** Base directory for worktrees. Defaults to sibling of repo (<repo>--<branch>). */
   worktreeBaseDir?: string;
+  notificationsEnabled?: boolean;
 }
 
 export interface ElectronAPI {
@@ -109,6 +110,7 @@ export interface ElectronAPI {
   ) => () => void;
   onUpdateError: (callback: (info: { error: string }) => void) => () => void;
   onMenuSettings: (callback: () => void) => () => void;
+  onNavigateToSession: (callback: (sessionId: string) => void) => () => void;
 }
 
 declare global {


### PR DESCRIPTION
## Summary

- **Unread state**: Sessions that transition to `waiting_for_input` while not the active session get marked as unread with a persistent chat bubble in the sidebar. The bubble clears after viewing the session for 1.5s, or when the session resumes/archives.
- **Cmd+U shortcut**: Manually marks the active session as unread (hold Cmd to see a "U" badge hint on the active session).
- **macOS notifications**: When the window is not focused and a session starts waiting for input, a native macOS notification fires. Clicking it focuses the window and navigates to that session.
- **Settings toggle**: A new "Notifications" section in Settings lets you enable/disable macOS notifications.

## Test plan

- [x] 10 new tests for unread state in `sessionStore.test.ts`
- [x] 4 new tests for `isMarkUnreadShortcut` in `useGlobalShortcuts.test.ts`
- [x] All 56 renderer/shared tests pass
- [x] Biome lint clean
- [ ] Manual: Start two sessions, switch to one, let the other finish → bubble appears on background session
- [ ] Manual: Click the unread session, wait 1.5s → bubble clears
- [ ] Manual: Click away before 1.5s → bubble persists
- [ ] Manual: Cmd+U on active session → marks it unread
- [ ] Manual: Hold Cmd → "U" badge shows on active session
- [ ] Manual: Minimize window, let session finish → macOS notification appears
- [ ] Manual: Click notification → window focuses, switches to that session
- [ ] Manual: Toggle notifications off in settings → no more notifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)