### PR TITLE
feat: show worktree path and branch name in top bar

### DIFF
--- a/src/renderer/components/SessionView/SessionView.tsx
+++ b/src/renderer/components/SessionView/SessionView.tsx
@@ -53,17 +53,8 @@ export function SessionView() {
     if (!isRunning) setEscPrimed(false);
   }, [isRunning]);
 
-  // Fetch branch name for the active session's repo
-  const [branchName, setBranchName] = useState<string | null>(null);
-  useEffect(() => {
-    if (!session?.repoPath) {
-      setBranchName(null);
-      return;
-    }
-    window.electronAPI.getRepoBranch(session.repoPath).then(setBranchName);
-  }, [session?.repoPath]);
-
-  const folderName = session?.repoPath.split("/").pop() || session?.repoPath;
+  const worktreePath = session?.worktreePath;
+  const branchName = session?.branchName ?? null;
 
   if (!activeSessionId || !session) {
     return (
@@ -84,7 +75,7 @@ export function SessionView() {
     <div className="flex-1 flex flex-col min-h-0">
       {/* Session header */}
       <div className="h-10 flex items-center px-4 border-b border-border gap-2">
-        <span className="text-sm font-medium text-text-primary font-mono">{folderName}</span>
+        <span className="text-sm font-medium text-text-primary font-mono">{worktreePath}</span>
         {branchName && <span className="text-xs text-text-muted font-mono">{branchName}</span>}
         <StatusBadge status={session.status} />
       </div>


### PR DESCRIPTION
## Summary

Display the session's worktree path and branch name in the top bar, replacing the confusing repo folder name + main branch display.

## What Changed

- **SessionView.tsx**: Removed dynamic branch fetching from main repo; now reads `worktreePath` and `branchName` directly from `SessionInfo`
- The top bar now shows the full worktree directory path and the session's actual branch name

## Why

Previously, the top bar showed:
- Repo folder name (last segment of repo path) - confusing when multiple worktrees exist
- Main repo's checked-out branch - misleading since the session runs in a worktree, not the main repo

Now it correctly shows:
- Full worktree path (e.g. `/Users/daniel.klevebring/worktrees/codez--top-bar`)
- Session's branch name (e.g. `top-bar`)

## Testing

Verified in dev app - top bar now displays correct context for sessions.