### PR TITLE
chore: add electron-log for persistent file logging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "better-sqlite3": "^12.6.2",
+        "electron-log": "^5.4.3",
         "electron-updater": "^6.8.3",
         "font-list": "^2.0.2",
         "node-pty": "^1.0.0",
@@ -4516,6 +4517,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/electron-log": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-5.4.3.tgz",
+      "integrity": "sha512-sOUsM3LjZdugatazSQ/XTyNcw8dfvH1SYhXWiJyfYodAAKOZdHs0txPiLDXFzOZbhXgAgshQkshH2ccq0feyLQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/electron-publish": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "better-sqlite3": "^12.6.2",
+    "electron-log": "^5.4.3",
     "electron-updater": "^6.8.3",
     "font-list": "^2.0.2",
     "node-pty": "^1.0.0",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,3 +1,4 @@
+import "./logger.js";
 import { execFileSync } from "node:child_process";
 import path from "node:path";
 import { app, BrowserWindow, Menu } from "electron";

--- a/src/main/logger.ts
+++ b/src/main/logger.ts
@@ -1,0 +1,10 @@
+import log from "electron-log/main";
+
+// Writes to ~/Library/Logs/Codez/main.log
+// Also forwards renderer console output to the same file via IPC
+log.initialize({ spyRendererConsole: true });
+
+// Override console so all existing console.log/error/warn calls are captured
+Object.assign(console, log.functions);
+
+export default log;


### PR DESCRIPTION
## Summary

Add persistent file logging via electron-log to diagnose why sessions stop mid-operation without warning.

## What Changed

- **Install electron-log v5.4.3** as a runtime dependency
- **Create src/main/logger.ts** to initialize electron-log at startup
  - Logs written to `~/Library/Logs/Codez/main.log`
  - Captures all `console.log`/`console.error` output automatically
  - Forwards renderer process console output via IPC
- **Update src/main/index.ts** to import logger as the first module

## Why

Previously, when sessions mysteriously stopped mid-operation, there were no logs to diagnose the cause. The main process would crash or restart, resetting all sessions to `idle`, but we had no way to see what went wrong.

With electron-log, every log message (including crash context from `node-pty`, `better-sqlite3`, etc.) is now written to a persistent file. The next time this issue occurs, `~/Library/Logs/Codez/main.log` will contain a complete diagnostic history.

## Testing

- ✅ All 227 unit/integration tests pass
- ✅ Build succeeds (TypeScript + Vite)
- ✅ Lint clean (no Biome issues)
- ✅ Logger integrates cleanly — zero changes to existing files except the import

The logger is transparent to existing code — all existing `console.log`/`console.error` calls are automatically captured without any modifications to those files.

## Next Steps

Monitor `~/Library/Logs/Codez/main.log` on the next occurrence of sessions stopping mid-operation.