### PR TITLE
feat: make URLs in terminal clickable with Cmd+click

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
+        "@xterm/addon-web-links": "0.12.0",
         "better-sqlite3": "^12.6.2",
         "electron-log": "^5.4.3",
         "electron-updater": "^6.8.3",
@@ -1160,72 +1161,6 @@
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@electron/windows-sign": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@electron/windows-sign/-/windows-sign-1.2.2.tgz",
-      "integrity": "sha512-dfZeox66AvdPtb2lD8OsIIQh12Tp0GNCRUDfBHIKGpbmopZto2/A8nSpYYLoedPIHpqkeblZ/k8OV0Gy7PYuyQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "cross-dirname": "^0.1.0",
-        "debug": "^4.3.4",
-        "fs-extra": "^11.1.1",
-        "minimist": "^1.2.8",
-        "postject": "^1.0.0-alpha.6"
-      },
-      "bin": {
-        "electron-windows-sign": "bin/electron-windows-sign.js"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
-    "node_modules/@electron/windows-sign/node_modules/fs-extra": {
-      "version": "11.3.4",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
-      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
-    "node_modules/@electron/windows-sign/node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@electron/windows-sign/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -3183,6 +3118,12 @@
         "@xterm/xterm": "^5.0.0"
       }
     },
+    "node_modules/@xterm/addon-web-links": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-web-links/-/addon-web-links-0.12.0.tgz",
+      "integrity": "sha512-4Smom3RPyVp7ZMYOYDoC/9eGJJJqYhnPLGGqJ6wOBfB8VxPViJNSKdgRYb8NpaM6YSelEKbA2SStD7lGyqaobw==",
+      "license": "MIT"
+    },
     "node_modules/@xterm/xterm": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
@@ -4353,15 +4294,6 @@
       "dependencies": {
         "buffer": "^5.1.0"
       }
-    },
-    "node_modules/cross-dirname": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/cross-dirname/-/cross-dirname-0.1.0.tgz",
-      "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -8561,36 +8493,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
-      }
-    },
-    "node_modules/postject": {
-      "version": "1.0.0-alpha.6",
-      "resolved": "https://registry.npmjs.org/postject/-/postject-1.0.0-alpha.6.tgz",
-      "integrity": "sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "commander": "^9.4.0"
-      },
-      "bin": {
-        "postject": "dist/cli.js"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/postject/node_modules/commander": {
-      "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
-      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/prebuild-install": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.4",
     "@xterm/addon-fit": "^0.10.0",
+    "@xterm/addon-web-links": "0.12.0",
     "@xterm/xterm": "^5.5.0",
     "concurrently": "^8.2.2",
     "electron": "^40.4.1",

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -1,7 +1,7 @@
 import { execFileSync, spawn } from "node:child_process";
 import fs from "node:fs";
 import type Database from "better-sqlite3";
-import { app, type BrowserWindow, dialog, ipcMain } from "electron";
+import { app, type BrowserWindow, dialog, ipcMain, shell } from "electron";
 import { getFonts2 } from "font-list";
 import * as pty from "node-pty";
 import type { AgentType } from "../shared/agent-types.js";
@@ -396,5 +396,19 @@ export function registerIpcHandlers(options: RegisterHandlersOptions): void {
   ipcMain.handle(IPC.APP_GET_INFO, () => {
     const { app } = require("electron");
     return { name: app.getName(), version: app.getVersion() };
+  });
+
+  ipcMain.handle(IPC.APP_OPEN_EXTERNAL, (_event, url: string) => {
+    // Only allow http(s) and mailto schemes — block file:// and other schemes
+    // that could escape the sandbox by launching arbitrary handlers.
+    try {
+      const parsed = new URL(url);
+      if (parsed.protocol !== "http:" && parsed.protocol !== "https:" && parsed.protocol !== "mailto:") {
+        return;
+      }
+    } catch {
+      return;
+    }
+    shell.openExternal(url);
   });
 }

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -40,6 +40,7 @@ const CH = {
   SETTINGS_GET_ICON_DATA_URLS: "settings:getIconDataUrls",
   SETTINGS_SET_APP_ICON: "settings:setAppIcon",
   APP_GET_INFO: "app:getInfo",
+  APP_OPEN_EXTERNAL: "app:openExternal",
   UPDATER_CHECK: "updater:check",
   UPDATER_DOWNLOAD: "updater:download",
   UPDATER_QUIT_AND_INSTALL: "updater:quitAndInstall",
@@ -120,6 +121,7 @@ const api = {
 
   // App
   getAppInfo: () => ipcRenderer.invoke(CH.APP_GET_INFO),
+  openExternal: (url: string) => ipcRenderer.invoke(CH.APP_OPEN_EXTERNAL, url),
 
   // Updater
   checkForUpdate: () => ipcRenderer.invoke(CH.UPDATER_CHECK),

--- a/src/renderer/components/SessionView/TerminalView.tsx
+++ b/src/renderer/components/SessionView/TerminalView.tsx
@@ -1,5 +1,6 @@
 import type { AgentType } from "@shared/agent-types";
 import { FitAddon } from "@xterm/addon-fit";
+import { WebLinksAddon } from "@xterm/addon-web-links";
 import { type ITheme, Terminal } from "@xterm/xterm";
 import "@xterm/xterm/css/xterm.css";
 import { useEffect, useRef } from "react";
@@ -95,6 +96,7 @@ export function TerminalView({ sessionId, agentType, worktreePath, isActive }: T
     let resizeObserver: ResizeObserver | null = null;
     let unsubData: (() => void) | null = null;
     let unsubExit: (() => void) | null = null;
+    let linkTooltip: HTMLDivElement | null = null;
 
     const initRafId = requestAnimationFrame(() => {
       if (disposed) return;
@@ -113,6 +115,40 @@ export function TerminalView({ sessionId, agentType, worktreePath, isActive }: T
 
       fitAddon = new FitAddon();
       terminal.loadAddon(fitAddon);
+
+      // Cmd+click (macOS) on URLs opens them in the default browser.
+      // The addon underlines links on hover; the handler routes to Electron's
+      // shell.openExternal via IPC so the URL doesn't open in a new BrowserWindow.
+      // Tooltip is rendered imperatively because the link is inside xterm's canvas,
+      // not a React element — the addon's hover/leave callbacks drive show/hide.
+      linkTooltip = document.createElement("div");
+      linkTooltip.className =
+        "fixed pointer-events-none z-[9999] whitespace-nowrap rounded-md px-2 py-1 text-[11px] font-medium leading-none bg-elevated text-text-primary shadow-lg border border-border-subtle";
+      linkTooltip.style.display = "none";
+      linkTooltip.textContent = "Cmd + click to open link";
+      document.body.appendChild(linkTooltip);
+
+      terminal.loadAddon(
+        new WebLinksAddon(
+          (event, uri) => {
+            if (event.metaKey) {
+              window.electronAPI.openExternal(uri).catch(() => {});
+            }
+          },
+          {
+            hover: (event) => {
+              if (!linkTooltip) return;
+              linkTooltip.style.display = "block";
+              linkTooltip.style.left = `${event.clientX + 12}px`;
+              linkTooltip.style.top = `${event.clientY + 16}px`;
+            },
+            leave: () => {
+              if (linkTooltip) linkTooltip.style.display = "none";
+            },
+          },
+        ),
+      );
+
       terminal.open(container);
 
       terminalRef.current = terminal;
@@ -194,6 +230,8 @@ export function TerminalView({ sessionId, agentType, worktreePath, isActive }: T
       unsubExit?.();
       window.electronAPI.ptyKill(sessionId);
       terminal?.dispose();
+      linkTooltip?.remove();
+      linkTooltip = null;
       terminalRef.current = null;
       fitAddonRef.current = null;
       initializedRef.current = false;

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -46,6 +46,7 @@ export const IPC = {
 
   // App
   APP_GET_INFO: "app:getInfo",
+  APP_OPEN_EXTERNAL: "app:openExternal",
 
   // PTY
   PTY_CREATE: "pty:create",

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -100,6 +100,7 @@ export interface ElectronAPI {
 
   // App
   getAppInfo: () => Promise<{ name: string; version: string }>;
+  openExternal: (url: string) => Promise<void>;
 
   // PTY
   ptyCreate: (


### PR DESCRIPTION
## Summary

- Loads `@xterm/addon-web-links` so URLs in the PTY output underline on hover.
- Cmd+click routes the URL through a new `app:openExternal` IPC handler that calls `shell.openExternal` — opens in the user's default browser instead of spawning a new Electron `BrowserWindow`.
- URL scheme is validated in the main process (`http`, `https`, `mailto` only) so untrusted terminal output cannot launch arbitrary handlers via `file://` or custom schemes.
- A small "Cmd + click to open link" hint follows the cursor while hovering a link, styled to match the existing app tooltips.

## Test plan

- [x] `npm run dev` — start the app
- [x] In any session, surface a URL in the terminal (e.g. ask the agent to print one, or `echo https://github.com`)
- [x] Hover the URL — it underlines and the "Cmd + click to open link" pill appears near the cursor
- [x] Cmd+click the URL — opens in the default system browser (not a new Electron window)
- [x] Plain click on the URL — does nothing (intentional, prevents accidental launches)
- [x] If a `file://` URL is rendered, Cmd+click is silently blocked by the main-process scheme check
- [x] Switch sessions — tooltip from old session doesn't leak; new session works the same

## Screenshots
<img width="489" height="418" alt="Screenshot 2026-05-21 at 09 34 59" src="https://github.com/user-attachments/assets/3c1383c0-cc22-4f3b-a6d3-ecc765f87be1" />
<img width="489" height="418" alt="Screenshot 2026-05-21 at 09 35 09" src="https://github.com/user-attachments/assets/c283b8ab-4574-4752-b55c-52d96079e637" />
